### PR TITLE
Various aesthetic/usability improvements to frontend

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,39 @@
+name: Build - Web
+
+on:
+  push:
+    branches:
+      - js
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "greet"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 12
+      - uses: actions/checkout@v3
+        with:
+          ref: 'js'
+      - run: sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+      - run: git submodule update --init --recursive
+      - run: npm install
+      - run: npm install -g grunt-cli
+      - run: ./gradlew build -x ktlint
+      - run: ./gradlew ktlint
+      - run: grunt test
+      - run: ./gradlew dokka
+      - uses: actions/checkout@v3
+        with:
+          ref: 'gh-pages'
+          path: 'out'
+      - run: mv out/jvm jvm && rm -rf out/* && mv jvm out && grunt dist && mv doc out
+      - run: |
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'cs61c@berkeley.edu'
+          git commit -am "Automated build ${{ github.sha }}"
+          git push
+        working-directory: ./out

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ venus.iml
 
 # Tests
 final_output.bin
+
+.DS_Store

--- a/src/main/frontend/css/themes/venus.css
+++ b/src/main/frontend/css/themes/venus.css
@@ -31,19 +31,23 @@ body {
     width: 100%;
     height: 88vh;
     max-height: 88vh;
-    font-family: Courier New, Courier, monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 .section {
     padding: 0 1.5rem;
 }
 
+#bp-column {
+    width: 3%;
+}
+
 #pc-column {
-    width: 10%;
+    width: 12%;
 }
 
 #mc-column {
-    width: 20%;
+    width: 15%;
 }
 
 #bc-column {
@@ -67,7 +71,7 @@ body {
 }
 
 #program-listing {
-    font-family: Courier New, Courier, monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 #program-listing-body {
@@ -76,12 +80,18 @@ body {
 }
 
 #program-listing-body tr.is-breakpoint {
-    background-color: #ff3860;
-    color: white;
+    background-color: #FAEAE6;
+}
+
+#program-listing-body tr div.is-breakpoint {
+    background: #eb355a;
+    width: 1.2em;
+    height: 1.2em;
+    border-radius: 50%;
 }
 
 #program-listing-body tr.is-selected {
-    background-color: #00d1b2;
+    background-color: #2154A6;
     color: white;
 }
 
@@ -114,11 +124,11 @@ body {
 }
 
 #regs-tab-view {
-    font-family: Courier New, Courier, monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 #fregs-tab-view {
-    font-family: Courier New, Courier, monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     display: none;
 }
 
@@ -159,7 +169,7 @@ body {
 }
 
 #memory-table {
-    font-family: Courier New, Courier, monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     margin: auto;
     background-color: white;
 }
@@ -178,7 +188,7 @@ body {
 
 #console-output {
     height: 100%;
-    font-family: Courier New, Courier, monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 .tabs {
@@ -194,7 +204,7 @@ body {
 }
 
 #regs-tab-view .input {
-    font-family: Courier New, Courier, monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     border-width: 2px;
 }
 
@@ -203,7 +213,7 @@ body {
 }
 
 #fregs-tab-view .input {
-    font-family: Courier New, Courier, monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     border-width: 2px;
 }
 
@@ -212,13 +222,13 @@ body {
 }
 
 #cache-tab-view {
-    font-family: Courier New, Courier, monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     line-height: 1em;
     font-size: 0.9em;
 }
 
 #cache-tab-view .input {
-    font-family: Courier New, Courier, monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     border-width: 2px;
 }
 
@@ -227,13 +237,13 @@ body {
 }
 
 #settings-tab-view {
-    font-family: Courier New, Courier, monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     line-height: 1em;
     font-size: 0.9em;
 }
 
 #settings-tab-view .input {
-    font-family: Courier New, Courier, monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     border-width: 2px;
 }
 
@@ -247,6 +257,19 @@ body {
 
 .byte-column {
     width: 15%;
+}
+
+#regs-tab-view, #fregs-tab-view {
+    border: 1px solid #dbdbdb;
+}
+
+#regs-tab-view > .panel-block, #fregs-tab-view > .panel-block {
+  border: none;
+}
+
+#regs-tab-view > .panel-block > .field, #fregs-tab-view > .panel-block > .field {
+  margin-bottom: 0em;
+  padding: 0.5em;
 }
 
 .panel-block > .field {

--- a/src/main/frontend/css/themes/venus_dark.css
+++ b/src/main/frontend/css/themes/venus_dark.css
@@ -10,18 +10,17 @@
 }
 
 .theme-dark #program-listing {
-    font-family: Courier New, Courier, monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     background-color: black;
 }
 
 .theme-dark #program-listing-body tr.is-breakpoint {
-    background-color: #eb355a;
+    background-color: #3A2323;
     color: white;
 }
 
 .theme-dark #program-listing-body tr.is-selected {
-    background-color: #00927c;
-    color: white;
+    background-color: #2D6099;
 }
 
 .theme-dark #program-listing-container {
@@ -32,7 +31,7 @@
 }
 
 .theme-dark #memory-table {
-    font-family: Courier New, Courier, monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     margin: auto;
     background-color: black;
 }
@@ -46,7 +45,7 @@
 
 .theme-dark #console-output {
     height: 100%;
-    font-family: Courier New, Courier, monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     background-color: black;
     font-weight: bold;
     color: #CCCCCC;
@@ -58,21 +57,21 @@
 }
 
 .theme-dark #regs-tab-view .input {
-    font-family: Courier New, Courier, monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     border-width: 2px;
     background-color: black;
     font-weight: bold;
 }
 
 .theme-dark #fregs-tab-view .input {
-    font-family: Courier New, Courier, monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     border-width: 2px;
     background-color: black;
     font-weight: bold;
 }
 
 .theme-dark #cache-tab-view .input {
-    font-family: Courier New, Courier, monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     border-width: 2px;
     background-color: black;
     color: #CCCCCC;
@@ -189,8 +188,18 @@
     color: #fff;
 }
 
+.theme-dark .button.is-warning {
+    background-color: #947600;
+    border-color: transparent;
+    color: #fff;
+}
+
 .button.is-primary:hover, .button.is-primary.is-hovered {
     background-color: #007d6b;
+}
+
+.button.is-warning:hover, .button.is-warning.is-hovered {
+    background-color: #806600;
 }
 
 .theme-dark .button.is-primary.is-active, .theme-dark .button.is-primary:active {

--- a/src/main/frontend/index.html
+++ b/src/main/frontend/index.html
@@ -398,7 +398,7 @@
       <div class="tile">
         <div class="tile is-parent">
           <article class="tile is-child is-primary" id="simulator-controls-container">
-            <div class="field is-grouped is-grouped-centered" id="simulator-buttons" style="display:none;">
+            <div id="simulator-buttons" class="field is-grouped is-grouped-centered">
               <div class="control">
                 <button id="simulator-run" class="button is-primary" onclick="driver.run()">Run</button>
               </div>
@@ -417,23 +417,24 @@
               <div class="control">
                 <button id="simulator-trace" class="button is-primary" onclick="driver.trace()">Trace</button>
               </div>
+              <div class="control">
+                <button id="simulator-reassemble-simulator" class="button is-warning" onclick="driver.assembleSimulator()">Re-assemble from Editor</button>
+              </div>
             </div>
-            <div class="field is-grouped is-grouped-centered" id="simulator-assemble-buttons">
+            <div id="simulator-assemble-simulator-container" class="field is-grouped is-grouped-centered">
               <div class="control">
                 <button id="simulator-assemble-simulator" class="button is-primary" onclick="driver.assembleSimulator()">Assemble & Simulate from Editor</button>
-              </div>
-              <div class="control">
-                <button id="simulator-no-assemble" class="button" onclick="driver.noAssemble()">Cancel</button>
               </div>
             </div>
           </article>
         </div>
       </div>
       <div class="tile">
-        <div class="tile is-parent">
+        <div class="tile is-parent" id="program-listing-container-parent">
           <article class="tile is-child is-primary" id="program-listing-container">
             <table id="program-listing" class="table">
               <colgroup>
+                <col id="bp-column">
                 <col id="pc-column">
                 <col id="mc-column">
                 <col id="bc-column">
@@ -441,6 +442,7 @@
               </colgroup>
               <thead>
               <tr>
+                <th></th>
                 <th>PC</th>
                 <th>Machine Code</th>
                 <th>Basic Code</th>
@@ -1400,16 +1402,25 @@
                     </div>
                   </div>
                 </div>
-                <div class="panel-block">
+                <form onsubmit="if ($('#memMove').val() !== ''){driver.moveMemoryLocation($('#memMove').val());$('#memMove').val('');}; return false;">
+                  <div class="panel-block">
                     <div class="field is-horizontal">
-                      <div class="field-label">
-                        <label class="label is-small" for="memMove">Address:</label>
+                      <div class="field-label is-normal">
+                        <label class="label" for="memMove">Address:</label>
                       </div>
-                      <div class="field-body is-expanded">
-                        <input id="memMove" class="input is-small" onblur="if (this.value !== ''){driver.moveMemoryLocation(this.value);this.value='';}" spellcheck="false">
+                      <div class="field-body">
+                        <div class="field">
+                          <input id="memMove" class="input is-small" spellcheck="false">
+                        </div>
+                        <div class="field is-narrow">
+                          <div class="control">
+                            <input type="submit" class="button" value="Go">
+                          </div>
+                        </div>
                       </div>
                     </div>
-                </div>
+                  </div>
+                </form>
               </div>
               <div id="cache-tab-view">
                 <div id="numCacheLvls" class="panel-block">

--- a/src/main/kotlin/venus/Driver.kt
+++ b/src/main/kotlin/venus/Driver.kt
@@ -267,7 +267,6 @@ import kotlin.dom.removeClass
      * Opens and renders the editor.
      */
     @JsName("openEditor") fun openEditor() {
-        runEnd()
         openGenericMainTab("editor")
         js("codeMirror.refresh();")
     }
@@ -278,9 +277,6 @@ import kotlin.dom.removeClass
 
     @JsName("openGenericMainTab") fun openGenericMainTab(name: String) {
         Renderer.renderTab(name, Renderer.mainTabs)
-        if (name == "editor") {
-            Renderer.renderAssembleButtons()
-        }
         LS.set("defaultTab", name)
     }
 


### PR DESCRIPTION
General:
- Support for switching between tabs (e.g. "Editor" and "Simulator")
  without resetting simulator buttons / state. Added a "Re-assemble"
  button for students to click when they've edited things and want to
  re-assemble.

Simulator tab:
- Support for displaying breakpoints in simulator with dot (helps when
  the current instruction has a breakpoint and would otherwise be
  invisible)
- Less harsh colors: copied the blue/reds from JetBrains theme
- Modern fonts: copied monospace font ordering from bulma
- Support for proper search bar in the "Address" tab: can click Go or
  press enter now
- Only force-scroll the simulator instructions if the instruction is out
  of view
- More compact representation for registers

Some screenshots:
![venus_dark_mode_review](https://user-images.githubusercontent.com/773285/176482876-0dd46dc7-4efd-4dcd-8a0a-c49ea837de3c.png)
![venus_light_mode_review](https://user-images.githubusercontent.com/773285/176482868-29c90102-a79a-4676-9a49-8815fba82dae.png)
![venus_address_search](https://user-images.githubusercontent.com/773285/176482910-e563ef55-753a-4730-a3d0-d16eba87ccdf.png)


@jerowang PTAL? Lmk if a GIF or more screenshots would be helpful, or else feel free to try it out on your own locally too.

